### PR TITLE
replace figshare link with link to data page

### DIFF
--- a/_episodes/01-format-data.md
+++ b/_episodes/01-format-data.md
@@ -124,7 +124,9 @@ later in this workshop.
 > 
 > This is a real dataset, however, it has been simplified for this workshop.
 > If you're interested in exploring the full dataset further, but you can 
-> download it [from Figshare](FIXME add link) and work with it using exactly the same tools we’ll learn about today.  
+> download it from Figshare and work with it using exactly the same tools we’ll learn about today.  
+> 
+> For more information about the dataset and to download it from Figshare, check out the [Social Sciences workshop data page](http://www.datacarpentry.org/socialsci-workshop/data).
 {: .callout}
 
 


### PR DESCRIPTION
want to keep only one canonical link, in case we change the version of the dataset we're using, so we only need to change the figshare link in one location
