### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_episodes/00-intro.md
+++ b/_episodes/00-intro.md
@@ -17,7 +17,7 @@ keypoints:
 
 > If you do not have a spreadsheet program, install one using the instructions
 > in the link below.
-> * [Instructions to install a spreadsheet program.]({{site.baseurl}}/setup.html)
+> * [Instructions to install a spreadsheet program.](../setup.html)
 >
 {: .prereq}
 
@@ -71,11 +71,11 @@ or entry of the data within it.
 Nevertheless it is important to be aware of the limitations these data may present, and know how to assess if any problems are present and how to overcome them.
 
 > ## What this lesson will not teach you
-> 
+>
 > - How to do *statistics* in a spreadsheet
 > - How to do *plotting* in a spreadsheet
 > - How to *write code* in spreadsheet programs
-> 
+>
 > If you're looking to do this, a good reference is
 > [Head First Excel](https://www.amazon.com/Head-First-Excel-learners-spreadsheets/dp/0596807694/ref=sr_1_1?ie=UTF8&qid=1491594584&sr=8-1&keywords=head+first+excel), published by O'Reilly.
 {: .callout}
@@ -89,11 +89,11 @@ Nevertheless it is important to be aware of the limitations these data may prese
 
 ### Using Spreadsheets for Data Entry and Cleaning
 
-However, there are circumstances where you might want to use a spreadsheet 
-program to produce “quick and dirty” calculations or figures, and some of 
-these features can be used in data cleaning, prior to importation into a 
-statistical analysis program. We will show you how to use some features of 
-spreadsheet programs to check your data quality along the way and produce 
+However, there are circumstances where you might want to use a spreadsheet
+program to produce “quick and dirty” calculations or figures, and some of
+these features can be used in data cleaning, prior to importation into a
+statistical analysis program. We will show you how to use some features of
+spreadsheet programs to check your data quality along the way and produce
 preliminary summary statistics.
 
 In this lesson, we will assume that you are most likely using Excel as

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 
 ## Instructor notes
@@ -127,20 +125,20 @@ even a reluctant audience started.
 
 ### How do you extract date components from the interview_date field in SAFI_clean.csv?
 
-The interview_date field in SAFI_clean.csv when saved to SAFI_clean.xlsx is difficult to 
-manage because there isn't a way to format the column as a date field, even using the 
-custom field formats. The easiest solution to this question is to show the student how to 
-extract the date information from the field. Make a new column and format it as a date. 
-In the first cell of the new column type =LEFT(C2,10) and then apply this to the column. 
+The interview_date field in SAFI_clean.csv when saved to SAFI_clean.xlsx is difficult to
+manage because there isn't a way to format the column as a date field, even using the
+custom field formats. The easiest solution to this question is to show the student how to
+extract the date information from the field. Make a new column and format it as a date.
+In the first cell of the new column type =LEFT(C2,10) and then apply this to the column.
 This function extracts the first 10 characters from the left side of the interview_date
-field and inserts them into a new column. 
+field and inserts them into a new column.
 
 ### How would you automatically transform the items_owned field into a usable format?
 
 If you are not following the course immediately with the OpenRefine lesson it is important
-to make it clear that in the current format SAFI_clean.csv is not ready for analysis. 
-The items_owned column ideally needs to be split into separate yes / no / null columns. 
+to make it clear that in the current format SAFI_clean.csv is not ready for analysis.
+The items_owned column ideally needs to be split into separate yes / no / null columns.
 Example: set up a new column 'bicycle' and format it as a number. You then need to extract
-information from the items_owned column about whether the word 'bicycle' is in the column. 
-One way of doing this is to use an IF statement: =IF(ISNUMBER(SEARCH("bicycle",K2))1,0). 
-The IF statement can include a wild character e.g. "bicy*". 
+information from the items_owned column about whether the word 'bicycle' is in the column.
+One way of doing this is to use an IF statement: =IF(ISNUMBER(SEARCH("bicycle",K2))1,0).
+The IF statement can include a wild character e.g. "bicy*".

--- a/index.md
+++ b/index.md
@@ -1,17 +1,18 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 
-Good data organization is the foundation of any research project. Most 
+Good data organization is the foundation of any research project. Most
 researchers have data in spreadsheets, so it's the place that many research
-projects start. 
+projects start.
 
-Typically we organize data in spreadsheets in ways that we as humans want to work with the data. However 
+Typically we organize data in spreadsheets in ways that we as humans want to work with the data. However
 computers require data to be organized in particular ways. In order
-to use tools that make computation more efficient, such as programming 
-languages like R or Python, we need to structure our data the way that 
-computers need the data. Since this is where most research projects start, 
+to use tools that make computation more efficient, such as programming
+languages like R or Python, we need to structure our data the way that
+computers need the data. Since this is where most research projects start,
 this is where we want to start too!
 
 In this lesson, you will learn:
@@ -26,7 +27,7 @@ In this lesson, however, you will *not* learn about data analysis with spreadshe
 Much of your time as a researcher will be spent in the initial 'data wrangling'
 stage, where you need to organize the data to perform a proper analysis later.
 It's not the most fun, but it is necessary. In this lesson you will
-learn how to think about data organization and some practices for more 
+learn how to think about data organization and some practices for more
 effective data wrangling. With this approach you can better format current data
 and plan new data collection so less data wrangling is needed.
 
@@ -34,21 +35,21 @@ and plan new data collection so less data wrangling is needed.
 > ## Getting Started
 >
 > Data Carpentry's teaching is hands-on, so participants are encouraged to use
-> their own computers to ensure the proper setup of tools for an efficient 
+> their own computers to ensure the proper setup of tools for an efficient
 > workflow. <br>**These lessons assume no prior knowledge of the skills or tools.**
 >
-> To get started, follow the directions in the "[Setup](setup.html)" tab to 
+> To get started, follow the directions in the "[Setup](setup.html)" tab to
 > download data to your computer and follow any installation instructions.
 >
 > #### Prerequisites
 >
 > This lesson requires a working copy of spreadsheet software, such as Microsoft
 > Excel or LibreOffice or OpenOffice.org (see more details in "[Setup](setup.html)").
-> <br>To most effectively use these materials, please make sure to install 
+> <br>To most effectively use these materials, please make sure to install
 > everything *before* working through this lesson.
 {: .prereq}
 
 > ## For Instructors
-> If you are teaching this lesson in a workshop, please see the 
-> [Instructor notes](guide/).
+> If you are teaching this lesson in a workshop, please see the
+> [Instructor notes](guide/index.html).
 {: .prereq}

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Setup
 ---
 


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Data Carpentry Lessons page](https://datacarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://datacarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.