### PR TITLE
Remove confusing speaker notes from Formating Data Tables in Spreadsheets lesson

### DIFF
--- a/_episodes/01-format-data.md
+++ b/_episodes/01-format-data.md
@@ -113,7 +113,7 @@ total number of livestock. All we need to do is sum the values in each row to
 find a total. We'll be learning how to do this computationally and reproducibly
 later in this workshop.
 
-> ## Workshop Data
+> ## Workshop Data 
 >
 >> The data used in these lessons are taken from interviews of farmers in two
 > countries in eastern sub-Saharan Africa (Mozambique and Tanzania). These

--- a/_episodes/01-format-data.md
+++ b/_episodes/01-format-data.md
@@ -113,14 +113,9 @@ total number of livestock. All we need to do is sum the values in each row to
 find a total. We'll be learning how to do this computationally and reproducibly
 later in this workshop.
 
-> ## Introduce the Data
+> ## Workshop Data
 >
-> If not already discussed, introduce the dataset that will be used in this
-> lesson, and in the other Social Sciences lessons, the [Studying African
-> Farmer-led Irrigation (SAFI)
-> Dataset](http://www.datacarpentry.org/socialsci-workshop/data).
->
-> The data used in these lessons are taken from interviews of farmers in two
+>> The data used in these lessons are taken from interviews of farmers in two
 > countries in eastern sub-Saharan Africa (Mozambique and Tanzania). These
 > interviews were conducted between November 2016 and June 2017 and probed
 > household features (e.g. construction materials used, number of household


### PR DESCRIPTION
Renamed the  "Introduce the Data" section to "Workshop Data" and removed the first sentence which is really a speaker note rather than training content. I tested the changes in a Markdown Live Preview app and they seem to render fine.

Rationale for the change: The "Introduce the Data" heading and first sentence after it is a call-to-action for the trainer rather than for learners to read. All other content in the lesson is directed to the learner and flows really well, but personally I find this section heading and first sentence confusing: I lose the flow when trying to present the material when I encounter these speaker notes.  The proposal is:  rename this Pinned section  to "Workshop Data" and delete the first sentence. This means there are no longer any speaker notes in the content of this lesson and hopefully it will flow more easily, for both the trainer and the learner.

Hope this helps!