### PR TITLE
Change heading from 'Mac OS X' to 'macOS'

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -48,7 +48,7 @@ title: Setup
 > - Once the installer is downloaded, double click on it and LibreOffice should
 >   install.
 >
-> #### Mac OS X
+> #### macOS
 >
 > - Download the Installer
 >  - Install LibreOffice by going to [the installation


### PR DESCRIPTION
The Mac operating system changed name a few years ago. This page has got the new name in one place already. I've suggested the second and final place.