### PR TITLE
Fix anchor labels and floating table

### DIFF
--- a/episodes/02-common-mistakes.md
+++ b/episodes/02-common-mistakes.md
@@ -124,7 +124,7 @@ Blanks (most applications) and NA (for R) are good choices. White et al, 2013, e
 
 ![](fig/better-formatting.png){alt='good formatting'}
 
-## Using formatting to make the data sheet look pretty {#formatting\-pretty}
+## Using formatting to make the data sheet look pretty {#formatting-pretty}
 
 **Example**: merging cells.
 
@@ -150,7 +150,7 @@ another field and specify the units the cell is in.
 **Solution**: Don't include more than one piece of information in a cell. This will limit the ways in which you can analyze your data.
 If you need both these types of information (the total number of animals and the types), design your data sheet to include this information. For example, include a separate column for each type of livestock.
 
-## Using problematic field names {#field\-name}
+## Using problematic field names {#field-name}
 
 Choose descriptive field names, but be careful not to include spaces, numbers, or special characters of any kind. Spaces can be
 misinterpreted by parsers that use whitespace as delimiters and some programs don't like field names that are text strings that start

--- a/episodes/02-common-mistakes.md
+++ b/episodes/02-common-mistakes.md
@@ -162,38 +162,13 @@ that are excessively long. Including the units in the field names avoids confusi
 
 **Examples**
 
-<table align = "left" style = "width =50%; border: 1px solid black;">
-<tr>
-	<td> <b>Good Name</b></td> <br />
-	<td> <b>Good Alternative </b> </td><br />
-	<td> <b>Avoid </b></td><br />
-</tr>
-<tr>
-	<td> wall_type </td>
-	<td> WallType </td>
-	<td> wall type </td>
-</tr>
-<tr>
-	<td> longitude </td>
-	<td> GpsLongitude </td>
-	<td> gps:Longitude </td>	
-</tr>	
-<tr>
-	<td> gender </td>
-	<td> gender </td>	
-	<td> M/F </td>
-</tr>
-<tr>
-	<td> Informant_01 </td>
-	<td> first_informant</td>
-	<td> 1st Inf</td>
-</tr>
-<tr>
-	<td> age_18 </td>
-	<td> years18</td>
-	<td> 18years</td>
-</tr>
-</table>
+| Good Name    | Good Alternative | Avoid         |
+|--------------|------------------|---------------|
+| wall_type    | WallType         | wall type     |
+| longitude    | GpsLongitude     | gps:Longitude |
+| gender       | gender           | M/F           |
+| Informant_01 | first_informant  | 1st Inf       |
+| age_18       | years18          | 18years       |
 
 ## Using special characters in data {#special}
 

--- a/episodes/02-common-mistakes.md
+++ b/episodes/02-common-mistakes.md
@@ -162,13 +162,38 @@ that are excessively long. Including the units in the field names avoids confusi
 
 **Examples**
 
-| Good Name    | Good Alternative | Avoid         |
-|--------------|------------------|---------------|
-| wall_type    | WallType         | wall type     |
-| longitude    | GpsLongitude     | gps:Longitude |
-| gender       | gender           | M/F           |
-| Informant_01 | first_informant  | 1st Inf       |
-| age_18       | years18          | 18years       |
+<table align = "left" style = "width =50%; border: 1px solid black;">
+<tr>
+	<td> <b>Good Name</b></td> <br />
+	<td> <b>Good Alternative </b> </td><br />
+	<td> <b>Avoid </b></td><br />
+</tr>
+<tr>
+	<td> wall_type </td>
+	<td> WallType </td>
+	<td> wall type </td>
+</tr>
+<tr>
+	<td> longitude </td>
+	<td> GpsLongitude </td>
+	<td> gps:Longitude </td>	
+</tr>	
+<tr>
+	<td> gender </td>
+	<td> gender </td>	
+	<td> M/F </td>
+</tr>
+<tr>
+	<td> Informant_01 </td>
+	<td> first_informant</td>
+	<td> 1st Inf</td>
+</tr>
+<tr>
+	<td> age_18 </td>
+	<td> years18</td>
+	<td> 18years</td>
+</tr>
+</table>
 
 ## Using special characters in data {#special}
 


### PR DESCRIPTION
This fixes #159 by removing the backslashes from the anchor names.

It also puts the table of problematic field names back into the normal document flow, instead of having it float.