### PR TITLE
Fix heading levels, remove empty section, add backticks

### DIFF
--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -2,8 +2,6 @@
 title: Instructor Notes
 ---
 
-## Instructor notes
-
 ## Lesson motivation and learning objectives
 
 The purpose of this lesson is not to teach how to do data analysis in spreadsheets,
@@ -12,7 +10,7 @@ quality control in a spreadsheet program.
 
 ## Lesson design
 
-#### [Introduction](../episodes/00-intro.md)
+### [Introduction](../episodes/00-intro.md)
 
 - Introduce that we're teaching data organization, and that we're using
   spreadsheets, because most people do data entry in spreadsheets or
@@ -31,7 +29,7 @@ quality control in a spreadsheet program.
   of the data in the spreadsheet. What are the pain points!?
 - As people answer highlight some of these issues with spreadsheets
 
-#### [Formatting data](../episodes/01-format-data.md)
+### [Formatting data](../episodes/01-format-data.md)
 
 - Introduce the dataset that will be used in this lesson, and in the other Social Sciences lessons, the [Studying African Farmer-led Irrigation (SAFI) Dataset](https://www.datacarpentry.org/socialsci-workshop/data).
 - Go through the point about keeping track of your steps and keeping raw data raw
@@ -51,12 +49,12 @@ quality control in a spreadsheet program.
   date into three columns using Excel's built in MONTH, DAY, YEAR functions. Have them
   run through that exercise.
 
-#### [Common formatting problems](../episodes/02-common-mistakes.md)
+### [Common formatting problems](../episodes/02-common-mistakes.md)
 
 - **Don't go through this chapter** except to refer to as responses to the exercise in
   the previous chapter.
 
-#### [Dates as data](../episodes/03-dates-as-data.md)
+### [Dates as data](../episodes/03-dates-as-data.md)
 
 - Do the exercise and make the point about dates either in response to a learner bringing
   up date as an issue during the responses, or at the end of the response time.
@@ -70,22 +68,22 @@ quality control in a spreadsheet program.
   the date has been pre-pended by an apostrophe. For example 21/11/2016 becomes '21/11/2016. Edit the cell to
   remove the apostrophe. You will then find that the day(), month() and year() functions work.
 
-#### [Quality assurance](../episodes/04-quality-assurance.md)
+### [Quality assurance](../episodes/04-quality-assurance.md)
 
 The challenge with this lesson is that the instructor's version of the spreadsheet software is going to look different than about half the room's. It makes
 it challenging to show where you can find menu options and navigate through.
 
 Instead discuss the concepts of quality control, and how things like sorting can help you find outliers in your data.
 
-#### [Exporting data](../episodes/05-exporting-data.md)
+### [Exporting data](../episodes/05-exporting-data.md)
 
 - Have the students export their cleaned data as CSV. Reiterate again the need for
   data in this format for the other tools we'll be using.
 
-#### Concluding points
+### Concluding points
 
 - Now your data is organized so that a computer can read and understand it. This
-  let's you use the full power of the computer for your analyses as we'll see in the
+  lets you use the full power of the computer for your analyses as we'll see in the
   rest of the workshop.
 - While your data is now neatly organized, it still might have errors or missing data
   or other problems. It's like you put all your data in the right drawers, but the
@@ -103,7 +101,7 @@ learning environment.
 
 ## Common problems
 
-#### Excel looks and acts different on different operating systems
+### Excel looks and acts different on different operating systems
 
 The main challenge with this lesson is that Excel looks very different and how you
 do things is even different between Mac and PC, and between different versions of
@@ -115,13 +113,13 @@ likely won't be able to cover all the different versions of Excel.
 If you have a helper who has experience with the other OS than you, it would be good
 to prep them to help with this lesson and tell how people to do things in the other OS.
 
-#### Apple Numbers
+### Apple Numbers
 
 Apple Numbers does not have data validation, which is needed for part of this lesson. A note
 is included in the setup instructions pointing Numbers users to either Microsoft Excel
 or LibreOffice.
 
-#### People are not interactive or responsive on the Exercise
+### People are not interactive or responsive on the Exercise
 
 This lesson depends on people working on the exercise and responding with things
 that are fixed. If your audience is reluctant to participate, start out with
@@ -136,7 +134,7 @@ The interview\_date field in SAFI\_clean.csv when saved to SAFI\_clean.xlsx is d
 manage because there isn't a way to format the column as a date field, even using the
 custom field formats. The easiest solution to this question is to show the student how to
 extract the date information from the field. Make a new column and format it as a date.
-In the first cell of the new column type =LEFT(C2,10) and then apply this to the column.
+In the first cell of the new column type `=LEFT(C2,10)` and then apply this to the column.
 This function extracts the first 10 characters from the left side of the interview\_date
 field and inserts them into a new column.
 
@@ -147,7 +145,5 @@ to make it clear that in the current format SAFI\_clean.csv is not ready for ana
 The items\_owned column ideally needs to be split into separate yes / no / null columns.
 Example: set up a new column 'bicycle' and format it as a number. You then need to extract
 information from the items\_owned column about whether the word 'bicycle' is in the column.
-One way of doing this is to use an IF statement: =IF(ISNUMBER(SEARCH("bicycle",K2))1,0).
-The IF statement can include a wild character e.g. "bicy\*".
-
-
+One way of doing this is to use an IF statement: `=IF(ISNUMBER(SEARCH("bicycle",K2))1,0)`.
+The IF statement can include a wild character e.g. `"bicy\*"`.


### PR DESCRIPTION
I wanted to print the instructor notes and found that there were some markup issues. This PR:

- Removes the empty first section "Instructor notes"
- Fixes heading levels: some subsections skipped level 3
- Changes "This let's" to "This lets"
- Adds backticks to a few inline formula examples
